### PR TITLE
Régler le problème des icones qui ne s'affichent pas sur utilitR

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 ################################# Default configuration ###################
-baseURL = "https://admiring-wing-dc4043.netlify.app/"
+baseURL = "https://www.utilitr.org/"
 title = "utilitR"
 theme = "airspace"
 # post pagination


### PR DESCRIPTION
Les icones sur la homepage sont issues de <https://ionicons.com/v2/>. Avant cette PR, elles ne s'affichaient pas

Close #3 